### PR TITLE
fix reponse type error between python2 and 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 
 # import all of this version information
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 __author__ = 'dave@springserve.com'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2016 Springserve'

--- a/springserve/__init__.py
+++ b/springserve/__init__.py
@@ -8,7 +8,7 @@ if six.PY3:
     from builtins import object
 
 
-__version__ = '0.7.1' #TODO: This is duplicated in the build.  Need to figure how to set this once 
+__version__ = '0.7.2' #TODO: This is duplicated in the build.  Need to figure how to set this once 
 
 import sys as _sys
 import json as _json


### PR DESCRIPTION
Fix the occasional stack trace below in `Vid-IO Staging Calls`

```
Traceback (most recent call last):
  File "python_src/springserve/qa/vidio_calls_staging.py", line 356, in <module>
    om_demand_tags, bidder_accounts, campaign_tiers)
  File "python_src/springserve/qa/vidio_calls_staging.py", line 220, in send_events
    for supply_tag in supply_tags:
  File "/usr/local/lib/python3.7/site-packages/springserve/__init__.py", line 319, in __iter__
    yield self[idx]
  File "/usr/local/lib/python3.7/site-packages/springserve/__init__.py", line 306, in __getitem__
    self._get_next_page()
  File "/usr/local/lib/python3.7/site-packages/springserve/__init__.py", line 280, in _get_next_page
    resp = self._service.get_raw(self._path_params, **params)
  File "/usr/local/lib/python3.7/site-packages/springserve/_decorators.py", line 54, in wrapped
    any([e in resp.content for e in AWS_ELB_ERROR_MESSAGES])
  File "/usr/local/lib/python3.7/site-packages/springserve/_decorators.py", line 54, in <listcomp>
    any([e in resp.content for e in AWS_ELB_ERROR_MESSAGES])
TypeError: a bytes-like object is required, not 'str'
Remote command failed with exit status 1
Failed: NonZeroResultCode: Remote command failed with exit status 1
```