### PR TITLE
Use extras_require for pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ To install from pip:
 
     pip install springserve
 
+
+To use the `Reporting API <https://springserve.atlassian.net/wiki/spaces/SSD/pages/1588035603/Reporting+API>`__
+with this package, also install `pandas <https://pypi.org/project/pandas/>`__.
+
 Usage
 -----------
 
@@ -140,7 +144,8 @@ easy to make calls that will return more than one result.
 
 ### SpringServe Reporting ###
 
-Below is the documentation for and an example of using SpringServe reporting
+Below is the documentation for and an example of using SpringServe reporting.
+This module requires the ``pandas`` package to be installed.
 
         In [10]: springserve.reports.run?
         Signature: springserve.reports.run(start_date=None, end_date=None, interval=None,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ CLASSIFIERS = ['Development Status :: 4 - Beta',
 EMAIL = ''
 SETUP_ARGS = {}
 REQUIRES = ['requests>=2.0.0', 'requests_oauthlib>=0.4.0',
-            'link>=0.3.1','xmltodict', 'pandas', 'six', 'requests-toolbelt' ]
+            'link>=0.3.1','xmltodict', 'six', 'requests-toolbelt' ]
+
+# The reporting API depends on pandas
+EXTRAS_REQUIRE = {'reporting': ['pandas']}
 
 # write out the version file so we can keep track on what version the built
 # package is
@@ -41,7 +44,8 @@ setup(name=__title__,
       maintainer=__author__,
       url=URL,
       packages=['springserve'],
-      install_requires = REQUIRES,
+      install_requires=REQUIRES,
+      extras_require=EXTRAS_REQUIRE,
       #data_files = DATA_FILES,
       classifiers=CLASSIFIERS,
       **SETUP_ARGS)


### PR DESCRIPTION
This PR is the `springserve-python` analog to https://github.com/9thbitio/link/pull/34. `pandas` becomes an [optional dependency](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) for the reporting API.