### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To install from pip:
     pip install springserve
 
 
-To use the `Reporting API <https://springserve.atlassian.net/wiki/spaces/SSD/pages/1588035603/Reporting+API>`__
-with this package, also install `pandas <https://pypi.org/project/pandas/>`__.
+To use the [Reporting API](https://springserve.atlassian.net/wiki/spaces/SSD/pages/1588035603/Reporting+API)
+with this package, also install [pandas](https://pypi.org/project/pandas/).
 
 Usage
 -----------
@@ -145,7 +145,7 @@ easy to make calls that will return more than one result.
 ### SpringServe Reporting ###
 
 Below is the documentation for and an example of using SpringServe reporting.
-This module requires the ``pandas`` package to be installed.
+This module requires the `pandas` package to be installed.
 
         In [10]: springserve.reports.run?
         Signature: springserve.reports.run(start_date=None, end_date=None, interval=None,


### PR DESCRIPTION
In PR #25, I added some links to the README file. However, I mistakenly thought this file was in RST/Sphinx format rather than Markdown.

This PR corrects the markup.