### PR TITLE
Mock link msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,10 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# Ipython Notebook
 .ipynb_checkpoints
+
+# IDE/OS/Misc
+.idea/
+.DS_Store/
+venv/

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 
 # import all of this version information
-__version__ = '0.8.10'
+__version__ = '0.8.11'
 __author__ = 'dave@springserve.com'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2016 Springserve'

--- a/springserve/__init__.py
+++ b/springserve/__init__.py
@@ -8,7 +8,7 @@ if six.PY3:
     from builtins import object
 
 
-__version__ = '0.8.10' #TODO: This is duplicated in the build.  Need to figure how to set this once 
+__version__ = '0.8.11' #TODO: This is duplicated in the build.  Need to figure how to set this once
 
 import sys as _sys
 import json as _json
@@ -24,6 +24,11 @@ try:
     _msg = _lnk.msg
 except:
     print("problem loading link, this is ok on the install")
+    class _MockMsg:
+        def __init__(self):
+            self.info = print
+            self.debug = print
+    _msg = _MockMsg()
 
 from ._decorators import raw_response_retry
 


### PR DESCRIPTION
Similarly to [this issue](https://github.com/SpringServe/springserve-python/issues/32), I encountered problems with logging when trying to use `set_credentials`. This method calls `API`, which assumes that the _msg logger has been created from link despite using inline credentials. To resolve this, I created a link msg-mocking class that will drop-in as a replacement when this exception is thrown to replaces the link msg methods with calls to `print`.